### PR TITLE
Fix bug with getting custom params and feature to validate using first password

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -182,7 +182,7 @@ class Payment {
         $params = [];
 
         foreach ($source as $key => $val) {
-            if (strpos($key, 'shp_')) {
+            if (stripos($key, 'shp_') === 0) {
                 $params[$key] = $val;
             }
         }

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -120,15 +120,15 @@ class Payment {
      *
      * @return bool
      */
-    public function validate($data)
+    public function validate($data, $passwordType = "validation")
     {
         $this->data = $data;
-
+        $password = $this->{"{$passwordType}Password"};
         $signature = vsprintf('%s:%u:%s%s', [
             // '$OutSum:$InvId:$password[:$params]'
             $data['OutSum'],
             $data['InvId'],
-            $this->validationPassword,
+            $password,
             $this->getCustomParamsString($this->data)
         ]);
 

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -300,4 +300,15 @@ class Payment {
 
         return $this;
     }
+    /**
+     * @param  string $name - custom param name, without shp_
+     * @return [type]       [description]
+     */
+    public function getCustomParam($name) {
+        $key = "shp_$name";
+        if(!isset($this->data[$key])) {
+            return null;
+        }
+        return $this->data[$key];
+    }
 }


### PR DESCRIPTION
``` php
            if (strpos($key, 'shp_')) {
                $params[$key] = $val;
            }
```

This code always ignore custom user variables, fixed by pull request.

In _Success_ and _Fail_ pages signature generated with `paymentPassword`(insted of `validationPassword` for result page) I have added way to check it by modifying  `validate` method.

And added way to getting custom variables from payment, by `getCustomParam`.
