### PR TITLE
Fix bug with getting custom params

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -182,7 +182,7 @@ class Payment {
         $params = [];
 
         foreach ($source as $key => $val) {
-            if (strpos($key, 'shp_')) {
+            if (stripos($key, 'shp_') === 0) {
                 $params[$key] = $val;
             }
         }


### PR DESCRIPTION
For now `strpos($key, 'shp_')` always return 0(false) for custom param, and `getCustomParamsString` does't works as need.
