### PR TITLE
fix http_build_query deprecation

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -123,8 +123,8 @@ class Payment
             $this->data['Receipt'] = urlencode(urlencode(json_encode($this->data['Receipt'])));
         }
 
-        $data = http_build_query($this->data, null, '&');
-        $custom = http_build_query($this->customParams, null, '&');
+        $data = http_build_query($this->data, '', '&');
+        $custom = http_build_query($this->customParams, '', '&');
 
         return $this->baseUrl . $data . ($custom ? '&' . $custom : '');
     }


### PR DESCRIPTION
fix "WARNING: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /vendor/idma/robokassa/src/Payment.php on line 127"